### PR TITLE
roi window basic

### DIFF
--- a/core/widgets/eventhandler.py
+++ b/core/widgets/eventhandler.py
@@ -1,0 +1,318 @@
+import numpy as np
+from matplotlib.patches import Rectangle
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+class EventHandler(QObject):
+    roi_changed = pyqtSignal(float, float, float, float, name='roiChanged')
+
+    def __init__(self, parent=None, multi_roi=False):
+        super().__init__(parent)
+
+        self.cur_xlim = None
+        self.cur_ylim = None
+        self.x0 = None
+        self.y0 = None
+        self.x1 = None
+        self.y1 = None
+
+        self.multi = multi_roi
+        self.rect_count = 0
+        self.rect_selected_key = -1
+        self.all_rect = {}
+        self.rect = None
+        self.rect_x0 = None
+        self.rect_y0 = None
+        self.rect_x1 = None
+        self.rect_y1 = None
+
+    def get_roi(self):
+        if self.rect_count:
+            rect = self.all_rect[self.rect_selected_key]
+            return rect.get_xy(), rect.get_width(), rect.get_height()
+        else:
+            return None, None, None
+
+    def set_roi(self, ax, xy, width, height):
+        if self.rect_selected_key >= 0:
+            self.all_rect[self.rect_selected_key].set_edgecolor('red')
+
+        rect = Rectangle(xy, width, height, linewidth=1, edgecolor='red', facecolor='none')
+        ax.add_patch(rect)
+        self.all_rect[self.rect_count] = rect
+        self.rect_selected_key = self.rect_count
+        self.rect_count += 1
+
+        ax.figure.canvas.draw()
+
+    def set_curr_roi(self, ax, xy, width, height):
+        if self.rect_selected_key >= 0:
+            rect = self.all_rect[self.rect_selected_key]
+            rect.set_xy(xy)
+            rect.set_width(width)
+            rect.set_height(height)
+            ax.figure.canvas.draw()
+        else:
+            rect = Rectangle(xy, width, height, linewidth=1, edgecolor='red', facecolor='none')
+            ax.add_patch(rect)
+            self.all_rect[self.rect_count] = rect
+            self.rect_selected_key = self.rect_count
+            self.rect_count += 1
+
+
+    def zoom_factory(self, ax, base_scale=1.05):
+        def zoom(event):
+            if not ax.in_axes(event): return
+
+            cur_xlim = ax.get_xlim()
+            cur_ylim = ax.get_ylim()
+
+            x, y = event.xdata, event.ydata
+            if event.button == 'down':
+                scale_factor = 1. / base_scale
+            elif event.button == 'up':
+                scale_factor = base_scale
+            else:
+                scale_factor = 1
+                print('[!] Error:zoom: {:s}'.format(event.button))
+
+            x_left = x - cur_xlim[0]
+            x_right = cur_xlim[1] - x
+            y_top = y - cur_ylim[0]
+            y_bottom = cur_ylim[1] - y
+
+            ax.set_xlim([x - x_left*scale_factor, x + x_right*scale_factor])
+            ax.set_ylim([y - y_top*scale_factor, y + y_bottom*scale_factor])
+            ax.figure.canvas.draw()
+
+        fig = ax.get_figure()
+        id = fig.canvas.mpl_connect('scroll_event', zoom)
+        return [id]
+
+    def pan_factory(self, ax):
+        def on_press(event):
+            if not ax.in_axes(event): return
+            if event.button != 1: return
+            self.cur_xlim = ax.get_xlim()
+            self.cur_ylim = ax.get_ylim()
+            self.x0 = event.xdata
+            self.y0 = event.ydata
+
+        def on_release(event):
+            if event.button != 1: return
+            self.cur_xlim = None
+            self.cur_ylim = None
+            self.x0 = None
+            self.y0 = None
+            ax.figure.canvas.draw()
+
+        def on_motion(event):
+            if not ax.in_axes(event): return
+            if event.button != 1: return
+            if self.x0 is None or self.y0 is None: return
+
+            dx = event.xdata - self.x0
+            dy = event.ydata - self.y0
+            self.cur_xlim -= dx
+            self.cur_ylim -= dy
+            ax.set_xlim(self.cur_xlim)
+            ax.set_ylim(self.cur_ylim)
+            ax.figure.canvas.draw()
+
+        fig = ax.get_figure()
+        id1 = fig.canvas.mpl_connect('button_press_event', on_press)
+        id2 = fig.canvas.mpl_connect('button_release_event', on_release)
+        id3 = fig.canvas.mpl_connect('motion_notify_event', on_motion)
+
+        return [id1, id2, id3]
+
+    def _find_closest_rect(self, x, y):
+        min_key = -1
+        min_dist = 9999999.
+        for key, rect in self.all_rect.items():
+            rect.set_edgecolor('gray')
+            xy = rect.get_xy()
+            width = rect.get_width()
+            height = rect.get_height()
+
+            _x0 = xy[0]
+            _y0 = xy[1]
+            _x1 = _x0 + width
+            _y1 = _y0 + height
+
+            x0, x1 = np.minimum(_x0, _x1), np.maximum(_x0, _x1)
+            y0, y1 = np.minimum(_y0, _y1), np.maximum(_y0, _y1)
+            if x <= x0 or x >= x1 or y <= y0 or y >= y1: continue
+
+            dist = np.min(np.abs([x0 - x, x1 - x, y0 - y, y1 - y]))
+            if dist < min_dist:
+                min_key = key
+                min_dist = dist
+
+        return min_key
+
+    def _remove_rect(self, key):
+        if key not in self.all_rect: return
+
+        self.all_rect[key].remove()
+        del self.all_rect[key]
+
+        all_rect = {}
+        rect_count = 0
+        for _, value in self.all_rect.items():
+            all_rect[rect_count] = value
+            rect_count += 1
+
+        if rect_count:
+            all_rect[rect_count - 1].set_edgecolor('red')
+
+        self.all_rect = all_rect
+        self.rect_count = rect_count
+        self.rect_selected_key = rect_count - 1
+
+    def roi_factory(self, ax):
+        def on_press(event):
+            if not ax.in_axes(event): return
+            if event.button == 1:
+                self.rect_x0 = event.xdata
+                self.rect_y0 = event.ydata
+                if not self.multi: self._remove_rect(0)
+            elif event.button == 3:
+                x, y = event.xdata, event.ydata
+                key = self._find_closest_rect(x, y)
+                self._remove_rect(key)
+                self.roi_changed.emit(0., 0., 0., 0.)
+                ax.figure.canvas.draw()
+
+        def on_release(event):
+            if event.button !=1: return
+            if self.rect is None: return
+            self.all_rect[self.rect_count] = self.rect
+            self.rect_selected_key = self.rect_count
+            self.rect_count += 1
+            self.rect = None
+
+        def on_motion(event):
+            if not ax.in_axes(event): return
+            if event.button != 1: return
+            if self.rect_x0 is None or self.rect_y0 is None: return
+
+            self.rect_x1 = event.xdata
+            self.rect_y1 = event.ydata
+            width = self.rect_x1 - self.rect_x0
+            height = self.rect_y1 - self.rect_y0
+            xy = self.rect_x0, self.rect_y0
+
+            if self.rect is None:
+                self.rect = Rectangle(xy, width, height, linewidth=1, facecolor='none', edgecolor='red')
+                ax.add_patch(self.rect)
+            else:
+                self.rect.set_width(width)
+                self.rect.set_height(height)
+                self.rect.set_xy(xy)
+
+            self.roi_changed.emit(xy[0], xy[1], width, height)
+
+            for key, value in self.all_rect.items():
+                value.set_edgecolor('gray')
+
+            ax.figure.canvas.draw()
+
+        fig = ax.get_figure()
+        id1 = fig.canvas.mpl_connect('button_press_event', on_press)
+        id2 = fig.canvas.mpl_connect('button_release_event', on_release)
+        id3 = fig.canvas.mpl_connect('motion_notify_event', on_motion)
+
+        return [id1, id2, id3]
+
+    def monitor_factory(self, ax, image_handler):
+
+        def _find_closest_rect(x, y):
+            min_key = -1
+            min_dist = 9999999.
+            for key, rect in self.all_rect.items():
+                rect.set_edgecolor('gray')
+                xy = rect.get_xy()
+                width = rect.get_width()
+                height = rect.get_height()
+
+                _x0 = xy[0]
+                _y0 = xy[1]
+                _x1 = _x0 + width
+                _y1 = _y0 + height
+
+                x0, x1 = np.minimum(_x0, _x1), np.maximum(_x0, _x1)
+                y0, y1 = np.minimum(_y0, _y1), np.maximum(_y0, _y1)
+                if x <= x0 or x >= x1 or y <= y0 or y >= y1: continue
+
+                dist = np.min(np.abs([x0 - x, x1 - x, y0 - y, y1 - y]))
+                if dist < min_dist:
+                    min_key = key
+                    min_dist = dist
+
+            return min_key
+
+        def on_press(event):
+            if not ax.in_axes(event): return
+
+            x = event.xdata
+            y = event.ydata
+            self.x0 = x
+            self.y0 = y
+            if self.rect_count:
+                selected_key = _find_closest_rect(x, y)
+                if event.button == 1:
+                    if selected_key >= 0:
+                        self.all_rect[selected_key].set_edgecolor('red')
+                        self.rect_selected_key = selected_key
+                    else:
+                        self.all_rect[self.rect_count-1].set_edgecolor('red')
+                        self.rect_selected_key = self.rect_count-1
+                    x1, y1 = self.all_rect[self.rect_selected_key].get_xy()
+                    self.x1 = x1
+                    self.y1 = y1
+                elif event.button == 3 and selected_key >= 0:
+                    self.all_rect[selected_key].remove()
+                    del self.all_rect[selected_key]
+                    all_rect = {}
+                    rect_count = 0
+                    for _, value in self.all_rect.items():
+                        all_rect[rect_count] = value
+                        rect_count += 1
+
+                    if rect_count:
+                        all_rect[rect_count-1].set_edgecolor('red')
+
+                    self.all_rect = all_rect
+                    self.rect_count = rect_count
+                    self.rect_selected_key = rect_count-1
+
+                ax.figure.canvas.draw()
+
+        def on_release(event):
+            self.x0 = None
+            self.y0 = None
+            self.x1 = None
+            self.y1 = None
+            self.rect = None
+
+        def on_motion(event):
+            if not ax.in_axes(event): return
+            if event.button != 1: return
+
+            x, y = event.xdata, event.ydata
+            #value = image_handler.get_cursor_data(event)
+
+            dx = x - self.x0
+            dy = y - self.y0
+            if self.rect_selected_key >= 0:
+                xy = self.x1 + dx, self.y1 + dy
+                self.all_rect[self.rect_selected_key].set_xy(xy)
+
+                ax.figure.canvas.draw()
+
+        fig = ax.get_figure()
+        id1 = fig.canvas.mpl_connect('button_press_event', on_press)
+        id2 = fig.canvas.mpl_connect('motion_notify_event', on_motion)
+        id3 = fig.canvas.mpl_connect('button_release_event', on_release)
+        return [id1, id2, id3]

--- a/core/widgets/mplcanvastool.py
+++ b/core/widgets/mplcanvastool.py
@@ -1,0 +1,171 @@
+import os
+from PyQt5 import QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.pyplot import Axes
+import numpy as np
+
+from core.widgets.eventhandler import EventHandler
+
+
+class MplCanvasTool(QtWidgets.QWidget):
+    def __init__(self, parent=None, width=5, height=4, dpi=100):
+        super().__init__(parent)
+
+        fig = Figure(figsize=(width, height), dpi=dpi)
+        ax = Axes(fig, [0., 0., 1., 1.])
+        ax.set_axis_off()
+        fig.add_axes(ax)
+        self.ax = ax
+        self.fig = fig
+        self.canvas = FigureCanvas(fig)
+
+        self._actions = {}
+        self._active = None
+        self._eventHandler = EventHandler()
+        self.roi_changed = self._eventHandler.roi_changed
+        self._ids = []
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.canvas)
+        layout.addLayout(self._get_toolbar())
+        layout.addLayout(self._get_roi_bar())
+        self.setLayout(layout)
+
+        self.image = None
+        self.image_handler = None
+        self.reset()
+
+    def _get_toolbar(self):
+        self.btn_home = QtWidgets.QPushButton('RESET')
+        self.btn_pan_zoom = QtWidgets.QPushButton('PAN/ZOOM')
+        self.btn_roi = QtWidgets.QPushButton('ROI')
+
+        self.btn_pan_zoom.setCheckable(True)
+        self.btn_roi.setCheckable(True)
+
+        self.btn_home.clicked.connect(self._on_reset)
+        self.btn_pan_zoom.clicked.connect(lambda: self._update_buttons('pan/zoom'))
+        self.btn_roi.clicked.connect(lambda: self._update_buttons('roi'))
+
+        self._actions['pan/zoom'] = self.btn_pan_zoom
+        self._actions['roi'] = self.btn_roi
+
+        layout = QtWidgets.QHBoxLayout()
+        layout.addWidget(self.btn_home)
+        layout.addWidget(self.btn_pan_zoom)
+        layout.addWidget(self.btn_roi)
+        return layout
+
+    def _get_roi_bar(self):
+
+        self.sp_x0 = QtWidgets.QDoubleSpinBox(self)
+        self.sp_y0 = QtWidgets.QDoubleSpinBox(self)
+        self.sp_w = QtWidgets.QDoubleSpinBox(self)
+        self.sp_h = QtWidgets.QDoubleSpinBox(self)
+
+
+        all = [self.sp_x0, self.sp_y0, self.sp_w, self.sp_h]
+        for sp in all:
+            sp.setMaximum(9999.)
+            sp.setMinimum(-9999.)
+            sp.setValue(0.)
+
+            sp.valueChanged.connect(self._update_roi_canvas)
+
+        self._eventHandler.roi_changed.connect(self._update_roi)
+
+        layout = QtWidgets.QHBoxLayout()
+        layout.addWidget(QtWidgets.QLabel('x0'))
+        layout.addWidget(self.sp_x0)
+        layout.addWidget(QtWidgets.QLabel('y0'))
+        layout.addWidget(self.sp_y0)
+        layout.addWidget(QtWidgets.QLabel('w'))
+        layout.addWidget(self.sp_w)
+        layout.addWidget(QtWidgets.QLabel('h'))
+        layout.addWidget(self.sp_h)
+        return layout
+
+    def _update_roi(self, x0, y0, w, h):
+        all = [self.sp_x0, self.sp_y0, self.sp_w, self.sp_h]
+        for sp in all: sp.valueChanged.disconnect(self._update_roi_canvas)
+
+        self.sp_x0.setValue(x0)
+        self.sp_y0.setValue(y0)
+        self.sp_w.setValue(w)
+        self.sp_h.setValue(h)
+
+        for sp in all: sp.valueChanged.connect(self._update_roi_canvas)
+
+    def _update_roi_canvas(self):
+        x0 = self.sp_x0.value()
+        y0 = self.sp_y0.value()
+        w = self.sp_w.value()
+        h = self.sp_h.value()
+
+        if x0 <= 0 or y0 <= 0 or w <= 0 or h <= 0:
+            return
+
+        self._eventHandler.set_curr_roi(self.ax, (x0, y0), w, h)
+
+    def _update_buttons(self, op_name):
+        if self._active == op_name:
+            self._active = None
+        else:
+            self._active = op_name
+
+        self._actions['pan/zoom'].setChecked(self._active == 'pan/zoom')
+        self._actions['roi'].setChecked(self._active == 'roi')
+
+        for id in self._ids:
+            self.canvas.mpl_disconnect(id)
+        self._ids = []
+
+        if self._active == 'pan/zoom':
+            zoom_ids = self._eventHandler.zoom_factory(self.ax)
+            pan_ids = self._eventHandler.pan_factory(self.ax)
+            self._ids = zoom_ids + pan_ids
+        elif self._active == 'roi':
+            roi_ids = self._eventHandler.roi_factory(self.ax)
+            self._ids = roi_ids
+        else:
+            pass
+            # if self.image_handler:
+            #     self._ids = self._eventHandler.monitor_factory(self.ax, self.image_handler)
+
+    def _on_reset(self):
+        if self.image_handler:
+            width = self.image.shape[1]
+            height = self.image.shape[0]
+            self.ax.set_xlim(0, width)
+            self.ax.set_ylim(height, 0)
+            self.canvas.draw()
+
+    def reset(self):
+        self.image_handler = None
+        self.image = None
+        self.ax.clear()
+        self.ax.set_axis_off()
+        self.canvas.draw()
+
+    def draw_image(self, image, cmap='gray', vmin=None, vmax=None):
+        if self.image_handler is None:
+            if vmin is None: vmin = np.min(image)
+            if vmax is None: vmax = np.max(image)
+            self.image_handler = self.ax.imshow(image, cmap=cmap, vmin=vmin, vmax=vmax)
+        else:
+            self.image_handler.set_data(image)
+        self.image = image
+
+        # if len(self._ids) == 0:
+        #     self._ids = self._eventHandler.monitor_factory(self.ax, self.image_handler)
+        self.canvas.draw()
+
+    def get_curr_roi(self):
+        return self._eventHandler.get_roi()
+
+    def set_roi(self, xy, width, height):
+        self._eventHandler.set_roi(self.ax, xy, width, height)
+
+    def set_curr_roi(self, xy, width, height):
+        self._eventHandler.set_curr_roi(self.ax, xy, width, height)

--- a/dpc_gpu_gui.py
+++ b/dpc_gpu_gui.py
@@ -9,6 +9,7 @@ from core.dpc_recon import DPCReconWorker, DPCReconFakeWorker
 from core.dpc_qt_utils import DPCStream
 
 from reconStep_gui import ReconStepWindow
+from roi_gui import RoiWindow
 
 import h5py
 import numpy as np
@@ -41,6 +42,8 @@ class MainWindow(QtWidgets.QMainWindow, ui_dpc.Ui_MainWindow):
 
         self.btn_recon_start.clicked.connect(self.start)
         self.btn_recon_stop.clicked.connect(self.stop)
+
+        self.btn_view_frame.clicked.connect(self.viewDataFrame)
 
         self.btn_gpu_all = [self.btn_gpu_0, self.btn_gpu_1, self.btn_gpu_2, self.btn_gpu_3]
 
@@ -339,8 +342,24 @@ class MainWindow(QtWidgets.QMainWindow, ui_dpc.Ui_MainWindow):
         '''
         Correspond to "View & set" in DPC GUI
         '''
-        pass
+        from core.widgets.mplcanvas import load_image_pil
+        image = load_image_pil('./test.tif')
+        self.roiWindow = RoiWindow(image=image)
+        self.roiWindow.roi_changed.connect(self._get_roi_slot)
+        self.roiWindow.show()
 
+    def _get_roi_slot(self, x0, y0, width, height):
+        '''
+        feel free to rename this function as you need
+        : this function to get roi when user click SEND button or
+        : dynamically...
+
+        x0: upper left x coordinate
+        y0: upper left y coordinate
+        width: width
+        height: height
+        '''
+        print(x0, y0, width, height)
 
     def loadExpParam(self): 
         '''

--- a/roi_gui.py
+++ b/roi_gui.py
@@ -2,16 +2,23 @@ import sys
 from PyQt5 import QtWidgets
 from ui import ui_roi
 
-from core.widgets.mplcanvas import load_image_pil
-
 class RoiWindow(QtWidgets.QMainWindow, ui_roi.Ui_MainWindow):
-    def __init__(self, parent=None):
+
+    def __init__(self, parent=None, image=None):
         super().__init__(parent)
         self.setupUi(self)
         QtWidgets.QApplication.setStyle('Plastique')
 
-        img = load_image_pil('./test.tif')
-        self.canvas.update_image(img)
+        # img = load_image_pil('./test.tif')
+        # self.canvas.draw_image(img)
+        if image is not None:
+            self.canvas.draw_image(image)
+
+        self.roi_changed = self.canvas.roi_changed
+
+
+
+
 
 
 if __name__ == '__main__':

--- a/ui/ui_dpc.py
+++ b/ui/ui_dpc.py
@@ -521,7 +521,7 @@ class Ui_MainWindow(object):
         spacerItem7 = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.gridLayout_5.addItem(spacerItem7, 0, 6, 1, 1)
         self.layoutWidget = QtWidgets.QWidget(self.tab_2)
-        self.layoutWidget.setGeometry(QtCore.QRect(20, 10, 713, 131))
+        self.layoutWidget.setGeometry(QtCore.QRect(20, 10, 681, 131))
         self.layoutWidget.setObjectName("layoutWidget")
         self.gridLayout_3 = QtWidgets.QGridLayout(self.layoutWidget)
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)

--- a/ui/ui_dpc_v2.ui
+++ b/ui/ui_dpc_v2.ui
@@ -1278,7 +1278,7 @@
        <rect>
         <x>20</x>
         <y>10</y>
-        <width>713</width>
+        <width>681</width>
         <height>131</height>
        </rect>
       </property>

--- a/ui/ui_roi.py
+++ b/ui/ui_roi.py
@@ -11,21 +11,15 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
-        MainWindow.resize(582, 600)
+        MainWindow.resize(454, 600)
         self.centralwidget = QtWidgets.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
         self.canvas = MplCanvasTool(self.centralwidget)
-        self.canvas.setGeometry(QtCore.QRect(10, 10, 561, 400))
+        self.canvas.setGeometry(QtCore.QRect(10, 10, 431, 400))
         self.canvas.setObjectName("canvas")
         self.groupBox = QtWidgets.QGroupBox(self.centralwidget)
         self.groupBox.setGeometry(QtCore.QRect(10, 420, 391, 141))
         self.groupBox.setObjectName("groupBox")
-        self.pushButton = QtWidgets.QPushButton(self.groupBox)
-        self.pushButton.setGeometry(QtCore.QRect(10, 30, 99, 27))
-        self.pushButton.setObjectName("pushButton")
-        self.pushButton_2 = QtWidgets.QPushButton(self.groupBox)
-        self.pushButton_2.setGeometry(QtCore.QRect(10, 60, 99, 27))
-        self.pushButton_2.setObjectName("pushButton_2")
         MainWindow.setCentralWidget(self.centralwidget)
 
         self.retranslateUi(MainWindow)
@@ -33,9 +27,7 @@ class Ui_MainWindow(object):
 
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "MainWindow"))
-        self.groupBox.setTitle(_translate("MainWindow", "Bad pixels"))
-        self.pushButton.setText(_translate("MainWindow", "Brightness"))
-        self.pushButton_2.setText(_translate("MainWindow", "Pick"))
+        MainWindow.setWindowTitle(_translate("MainWindow", "ROI "))
+        self.groupBox.setTitle(_translate("MainWindow", "Tools"))
 
-from core.widgets.mplcanvas import MplCanvasTool
+from core.widgets.mplcanvastool import MplCanvasTool

--- a/ui/ui_roi.ui
+++ b/ui/ui_roi.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>582</width>
+    <width>454</width>
     <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>ROI </string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <widget class="MplCanvasTool" name="canvas" native="true">
@@ -19,7 +19,7 @@
      <rect>
       <x>10</x>
       <y>10</y>
-      <width>561</width>
+      <width>431</width>
       <height>400</height>
      </rect>
     </property>
@@ -34,34 +34,8 @@
      </rect>
     </property>
     <property name="title">
-     <string>Bad pixels</string>
+     <string>Tools</string>
     </property>
-    <widget class="QPushButton" name="pushButton">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>30</y>
-       <width>99</width>
-       <height>27</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Brightness</string>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="pushButton_2">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>60</y>
-       <width>99</width>
-       <height>27</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Pick</string>
-     </property>
-    </widget>
    </widget>
   </widget>
  </widget>
@@ -69,7 +43,7 @@
   <customwidget>
    <class>MplCanvasTool</class>
    <extends>QWidget</extends>
-   <header>core.widgets.mplcanvas</header>
+   <header>core.widgets.mplcanvastool</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
- add roi window
- sample code is added to main window to describe the usages of the roi window

When the viewDataFrame button is clicked, it will pop up new window.
In the window, you can find three buttons. 
RESET: reset any rotation or translation changes 
ZOOM/PAN: allow users to zoom in/out and pan the image. for zooming, use mouse scroll and for panning using left button of mouse with dragging
ROI: allow users to draw a roi. use left mouse button to draw and right mouse button will delete the roi

Additionally, four spin boxes are used to show numbers related to the ROI drawn.
The first two are for x and y coordinate of the ROI and the others are for width and height of the ROI.

Any changes in the spin boxes or direct drawing will update each other. 

To get the changes from the MainWindow, one can connect roi_changed signal into a slot. 
Currently, the signal is connected _get_roi_slot function in the MainWindow and print out ROI for future usages. 